### PR TITLE
Add persistent configuration for environment filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,50 @@ slack_notifier = Nautilfer.new(endpoint: "#{slack_webhook_url}", adapter: :slack
 slack_notifier.notify("Deployment completed")
 ```
 
+### Control notifications by environment
+
+Use the environment controls to avoid sending notifications in non-production environments. The notifier checks the `environment` you pass in (defaulting to `ENV['NAUTILFER_ENV']`, `ENV['RAILS_ENV']`, or `ENV['RACK_ENV']`) and will only send messages when the environment is allowed.
+
+Enable notifications only in specific environments:
+
+```ruby
+Nautilfer.to_teams(
+  message: "Release deployed",
+  endpoint: "#{workflow_endpoint}",
+  environment: 'production',
+  enabled_environments: ['production']
+)
+```
+
+Or disable notifications for certain environments:
+
+```ruby
+Nautilfer.to_slack(
+  message: "Smoke tests running",
+  endpoint: "#{slack_webhook_url}",
+  environment: 'test',
+  disabled_environments: ['test', 'development']
+)
+```
+
+### Configure defaults once
+
+Persist your environment preferences by configuring defaults up front. New instances and helper calls will reuse these values unless you override them per call.
+
+```ruby
+Nautilfer.configure do |config|
+  config.environment = ENV['NAUTILFER_ENV']
+  config.enabled_environments = ['production']
+  config.disabled_environments = ['test']
+end
+
+notifier = Nautilfer.new(endpoint: "#{workflow_endpoint}", adapter: :teams)
+notifier.notify("Deployment finished")
+
+# Helpers will also reuse the configured defaults
+Nautilfer.to_slack(message: "Deployment finished", endpoint: "#{slack_webhook_url}")
+```
+
 ## Chatwork Notification Integration
 
 To enable Chatwork notifications, configure the API token and room ID:

--- a/lib/nautilfer.rb
+++ b/lib/nautilfer.rb
@@ -8,27 +8,78 @@ require "uri"
 class Nautilfer
   class Error < StandardError; end
 
-  def initialize(endpoint:, adapter: :teams)
+  class Configuration
+    attr_accessor :environment, :enabled_environments, :disabled_environments
+
+    def initialize
+      @enabled_environments = []
+      @disabled_environments = []
+    end
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
+
+  def self.reset_configuration!
+    @configuration = Configuration.new
+  end
+
+  def initialize(endpoint:, adapter: :teams, environment: nil, enabled_environments: nil, disabled_environments: nil)
+    config = self.class.configuration
+
     @endpoint = URI.parse(endpoint)
     @adapter = adapter
+    @environment = environment || config.environment || ENV['NAUTILFER_ENV'] || ENV['RAILS_ENV'] || ENV['RACK_ENV']
+    @enabled_environments = normalize_env_list(enabled_environments, config.enabled_environments)
+    @disabled_environments = normalize_env_list(disabled_environments, config.disabled_environments)
   end
 
   def notify(message)
+    return if notifications_disabled?
+
     payload, headers = build_payload(message)
     perform_request(payload, headers)
   end
 
-  def self.to_teams(message:, endpoint:)
-    new(endpoint: endpoint, adapter: :teams).notify(message)
+  def self.to_teams(message:, endpoint:, environment: nil, enabled_environments: nil, disabled_environments: nil)
+    new(
+      endpoint: endpoint,
+      adapter: :teams,
+      environment: environment,
+      enabled_environments: enabled_environments,
+      disabled_environments: disabled_environments
+    ).notify(message)
   end
 
-  def self.to_slack(message:, endpoint:)
-    new(endpoint: endpoint, adapter: :slack).notify(message)
+  def self.to_slack(message:, endpoint:, environment: nil, enabled_environments: nil, disabled_environments: nil)
+    new(
+      endpoint: endpoint,
+      adapter: :slack,
+      environment: environment,
+      enabled_environments: enabled_environments,
+      disabled_environments: disabled_environments
+    ).notify(message)
   end
 
   private
 
-  attr_reader :endpoint, :adapter
+  attr_reader :endpoint, :adapter, :environment, :enabled_environments, :disabled_environments
+
+  def normalize_env_list(custom_value, configured_value)
+    Array(custom_value.nil? ? configured_value : custom_value).compact
+  end
+
+  def notifications_disabled?
+    return true if disabled_environments.include?(environment)
+    return false if enabled_environments.empty?
+
+    !enabled_environments.include?(environment)
+  end
 
   def build_payload(message)
     case adapter

--- a/spec/nautilfer_spec.rb
+++ b/spec/nautilfer_spec.rb
@@ -89,6 +89,40 @@ RSpec.describe Nautilfer do
         ).once
       end
     end
+
+    context 'when the environment is not enabled' do
+      let(:notifier) do
+        described_class.new(
+          endpoint: endpoint,
+          adapter: :teams,
+          environment: 'development',
+          enabled_environments: ['production']
+        )
+      end
+
+      it 'does not send a notification' do
+        notifier.notify(message)
+
+        expect(WebMock).not_to have_requested(:post, endpoint)
+      end
+    end
+
+    context 'when the environment is explicitly disabled' do
+      let(:notifier) do
+        described_class.new(
+          endpoint: endpoint,
+          adapter: :teams,
+          environment: 'staging',
+          disabled_environments: ['staging']
+        )
+      end
+
+      it 'does not send a notification' do
+        notifier.notify(message)
+
+        expect(WebMock).not_to have_requested(:post, endpoint)
+      end
+    end
   end
 
   describe '.to_teams' do
@@ -149,6 +183,17 @@ RSpec.describe Nautilfer do
         headers: { 'Content-Type' => 'application/json' }
       ).once
     end
+
+    it 'does not send a request when environment is not enabled' do
+      Nautilfer.to_teams(
+        message: message,
+        endpoint: endpoint,
+        environment: 'development',
+        enabled_environments: ['production']
+      )
+
+      expect(WebMock).not_to have_requested(:post, endpoint)
+    end
   end
 
   describe '.to_slack' do
@@ -170,6 +215,124 @@ RSpec.describe Nautilfer do
         body: { "text" => message }.to_json,
         headers: { 'Content-Type' => 'application/json' }
       ).once
+    end
+
+    it 'does not send a request when environment is disabled' do
+      Nautilfer.to_slack(
+        message: message,
+        endpoint: endpoint,
+        environment: 'test',
+        disabled_environments: ['test']
+      )
+
+      expect(WebMock).not_to have_requested(:post, endpoint)
+    end
+  end
+
+  describe '.configure' do
+    let(:message) { "Configured message" }
+    let(:teams_endpoint) { "https://example.com/configured/teams" }
+    let(:slack_endpoint) { "https://example.com/configured/slack" }
+
+    after do
+      described_class.reset_configuration!
+    end
+
+    context 'when environment is enabled globally' do
+      before do
+        Nautilfer.configure do |config|
+          config.environment = 'production'
+          config.enabled_environments = ['production']
+        end
+
+        stub_request(:post, teams_endpoint)
+          .with(
+            body: {
+              "attachments" => [
+                {
+                  "contentType" => "application/vnd.microsoft.card.adaptive",
+                  "content" => {
+                    "$schema" => "http://adaptivecards.io/schemas/adaptive-card.json",
+                    "type" => "AdaptiveCard",
+                    "version" => "1.2",
+                    "body" => [
+                      {
+                        "type" => "TextBlock",
+                        "text" => message,
+                        "wrap" => true,
+                        "markdown" => true
+                      }
+                    ]
+                  }
+                }
+              ]
+            }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+          .to_return(status: 200, body: "", headers: {})
+
+        stub_request(:post, slack_endpoint)
+          .with(
+            body: { "text" => message }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+          .to_return(status: 200, body: "", headers: {})
+      end
+
+      it 'applies configuration to instances' do
+        notifier = Nautilfer.new(endpoint: teams_endpoint, adapter: :teams)
+        notifier.notify(message)
+
+        expect(WebMock).to have_requested(:post, teams_endpoint).once
+      end
+
+      it 'applies configuration to helper methods' do
+        Nautilfer.to_slack(message: message, endpoint: slack_endpoint)
+
+        expect(WebMock).to have_requested(:post, slack_endpoint).once
+      end
+    end
+
+    context 'when environment is disabled globally' do
+      before do
+        Nautilfer.configure do |config|
+          config.environment = 'development'
+          config.disabled_environments = ['development']
+        end
+
+        stub_request(:post, teams_endpoint)
+          .with(
+            body: {
+              "attachments" => [
+                {
+                  "contentType" => "application/vnd.microsoft.card.adaptive",
+                  "content" => {
+                    "$schema" => "http://adaptivecards.io/schemas/adaptive-card.json",
+                    "type" => "AdaptiveCard",
+                    "version" => "1.2",
+                    "body" => [
+                      {
+                        "type" => "TextBlock",
+                        "text" => message,
+                        "wrap" => true,
+                        "markdown" => true
+                      }
+                    ]
+                  }
+                }
+              ]
+            }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+          .to_return(status: 200, body: "", headers: {})
+      end
+
+      it 'skips notifications when configuration disables the environment' do
+        notifier = Nautilfer.new(endpoint: teams_endpoint, adapter: :teams)
+        notifier.notify(message)
+
+        expect(WebMock).not_to have_requested(:post, teams_endpoint)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- add a configurable global default for environment and filtering options
- apply configured defaults across instances and helper notification methods
- document and test persistent environment configuration behavior

## Testing
- bundle install *(fails: 403 Forbidden fetching gems from rubygems.org)*
- bundle exec rspec *(fails: rspec executable not installed because bundle install failed)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69196f3419708322a5f8693002114b70)