### PR TITLE
Add configurable message templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,27 @@ notifier = Nautilfer.new(endpoint: "#{workflow_endpoint}", adapter: :teams)
 notifier.notify("Deployment finished")
 ```
 
+### Configure message templates
+
+Define reusable message templates in the global configuration and select them when instantiating a notifier. Templates are callables that receive the original message and return the formatted text.
+
+```ruby
+Nautilfer.configure do |config|
+  config.message_templates = {
+    default: ->(message) { "[default] #{message}" },
+    headline: ->(message) { "## #{message}" }
+  }
+
+  config.default_message_template = :default
+end
+
+notifier = Nautilfer.new(endpoint: "#{workflow_endpoint}", adapter: :slack)
+notifier.notify("Deployment finished") # => sends "[default] Deployment finished"
+
+headline_notifier = Nautilfer.new(endpoint: "#{workflow_endpoint}", adapter: :slack, message_template: :headline)
+headline_notifier.notify("Deployment finished") # => sends "## Deployment finished"
+```
+
 ## Chatwork Notification Integration
 
 To enable Chatwork notifications using the unified adapter interface, initialize `Nautilfer` with the Chatwork adapter and tar

--- a/lib/nautilfer.rb
+++ b/lib/nautilfer.rb
@@ -13,11 +13,13 @@ class Nautilfer
   class Error < StandardError; end
 
   class Configuration
-    attr_accessor :environment, :enabled_environments, :disabled_environments
+    attr_accessor :environment, :enabled_environments, :disabled_environments, :message_templates, :default_message_template
 
     def initialize
       @enabled_environments = []
       @disabled_environments = []
+      @message_templates = { default: ->(message) { message } }
+      @default_message_template = :default
     end
   end
 
@@ -33,7 +35,7 @@ class Nautilfer
     @configuration = Configuration.new
   end
 
-  def initialize(endpoint:, adapter: Adapters::Teams.new, environment: nil, enabled_environments: nil, disabled_environments: nil)
+  def initialize(endpoint:, adapter: Adapters::Teams.new, environment: nil, enabled_environments: nil, disabled_environments: nil, message_template: nil)
     config = self.class.configuration
 
     @endpoint = URI.parse(endpoint)
@@ -41,6 +43,7 @@ class Nautilfer
     @environment = environment || config.environment || ENV['NAUTILFER_ENV'] || ENV['RAILS_ENV'] || ENV['RACK_ENV']
     @enabled_environments = normalize_env_list(enabled_environments, config.enabled_environments)
     @disabled_environments = normalize_env_list(disabled_environments, config.disabled_environments)
+    @message_template = resolve_message_template(message_template, config)
   end
 
   def notify(message)
@@ -52,7 +55,7 @@ class Nautilfer
 
   private
 
-  attr_reader :endpoint, :adapter, :environment, :enabled_environments, :disabled_environments
+  attr_reader :endpoint, :adapter, :environment, :enabled_environments, :disabled_environments, :message_template
 
   def resolve_adapter(adapter)
     resolved_adapter =
@@ -99,7 +102,28 @@ class Nautilfer
   end
 
   def build_payload(message)
-    [adapter.payload(message), adapter.headers]
+    [adapter.payload(apply_message_template(message)), adapter.headers]
+  end
+
+  def resolve_message_template(template_key, config)
+    return validate_message_template!(template_key) if template_key.respond_to?(:call)
+
+    key = template_key || config.default_message_template
+    resolved = config.message_templates[key]
+    resolved ||= config.message_templates[key.to_sym] if key.respond_to?(:to_sym)
+    raise Error, "Unknown message template: #{key}" unless resolved
+
+    validate_message_template!(resolved)
+  end
+
+  def validate_message_template!(template)
+    return template if template.respond_to?(:call)
+
+    raise Error, "Unsupported message template: #{template.inspect}"
+  end
+
+  def apply_message_template(message)
+    message_template.call(message)
   end
 
   def perform_request(payload, headers)

--- a/lib/nautilfer/version.rb
+++ b/lib/nautilfer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Nautilfer
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/spec/nautilfer_spec.rb
+++ b/spec/nautilfer_spec.rb
@@ -145,6 +145,60 @@ RSpec.describe Nautilfer do
         expect(WebMock).not_to have_requested(:post, endpoint)
       end
     end
+
+    context 'when a message template is configured' do
+      let(:message_templates) do
+        {
+          default: ->(msg) { "[default] #{msg}" },
+          plain: ->(msg) { msg }
+        }
+      end
+
+      before do
+        Nautilfer.configure do |config|
+          config.message_templates = message_templates
+          config.default_message_template = :default
+        end
+
+        stub_request(:post, endpoint)
+          .with(
+            body: { "text" => "[default] #{message}" }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+          .to_return(status: 200, body: "", headers: {})
+
+        stub_request(:post, "#{endpoint}/plain")
+          .with(
+            body: { "text" => message }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+          .to_return(status: 200, body: "", headers: {})
+      end
+
+      after do
+        described_class.reset_configuration!
+      end
+
+      it 'uses the default template from configuration' do
+        notifier = described_class.new(endpoint: endpoint, adapter: Nautilfer::Adapters::Slack.new)
+        notifier.notify(message)
+
+        expect(WebMock).to have_requested(:post, endpoint).with(
+          body: { "text" => "[default] #{message}" }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        ).once
+      end
+
+      it 'switches templates when specified at initialization' do
+        notifier = described_class.new(endpoint: "#{endpoint}/plain", adapter: Nautilfer::Adapters::Slack.new, message_template: :plain)
+        notifier.notify(message)
+
+        expect(WebMock).to have_requested(:post, "#{endpoint}/plain").with(
+          body: { "text" => message }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        ).once
+      end
+    end
   end
 
   describe '.configure' do


### PR DESCRIPTION
## Summary
- add configurable message templates with a configurable default
- apply selected templates when building adapter payloads and allow switching per instance
- document the template configuration workflow and add coverage for template usage

## Testing
- bundle exec rspec

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919b161564c8322966f2c2e7b707727)